### PR TITLE
Pathlib and extra features patch

### DIFF
--- a/sc2reaper/sc2reaper.py
+++ b/sc2reaper/sc2reaper.py
@@ -11,14 +11,6 @@ from pysc2 import run_configs
 from sc2reaper.sweeper import extract_all_info_once
 
 # Reading the set up from config.json found in the current working directory(cwd_):
-<<<<<<< HEAD
-with open(str(__file__).replace('sc2reaper.py', 'config.json')) as fp:
-    config = json.load(fp)
-    MATCH_UPS = config["MATCH_UPS"]
-    DB_NAME = config["DB_NAME"]
-    address = config["PORT_ADDRESS"]
-    port_num = config["PORT_NUMBER"]
-=======
 cwd_ = Path.cwd()
 config_ = (cwd_ / 'config.json')
 
@@ -65,7 +57,6 @@ else:
         DB_NAME = config["DB_NAME"]
         address = config["PORT_ADDRESS"]
         port_num = config["PORT_NUMBER"]
->>>>>>> ed773e7794ab82443bd7314a5cb9f4839ddd28fc
 
 # Entering the mongo instance
 

--- a/sc2reaper/score_extraction.py
+++ b/sc2reaper/score_extraction.py
@@ -13,8 +13,8 @@ def get_score(observation):
     observations, feel free to print score_obs (or obs.score).
     """
     score = {}
-
-    score_obs = observation.score.score_details
+    
+    score_obs = observation.score.score_details    
 
     score["collection_rate"] = {
         "minerals": score_obs.collection_rate_minerals,
@@ -22,6 +22,7 @@ def get_score(observation):
     }
 
     score["idle_worker_time"] = score_obs.idle_worker_time
+    score["idle_production_time"] = score_obs.idle_production_time
 
     score["killed_minerals"] = {
         "none": score_obs.killed_minerals.none,

--- a/sc2reaper/state_extraction.py
+++ b/sc2reaper/state_extraction.py
@@ -37,6 +37,7 @@ def get_state(observation):
         "total": supply_extraction.get_total_supply(observation),
         "army": supply_extraction.get_army_supply(observation),
         "workers": supply_extraction.get_worker_supply(observation),
+        "idle_workers": supply_extraction.get_idle_worker_count(observation)
     }
 
     allied_units = unit_extraction.get_allied_units(observation)  # holds unit docs.

--- a/sc2reaper/supply_extraction.py
+++ b/sc2reaper/supply_extraction.py
@@ -12,3 +12,6 @@ def get_army_supply(observation):
 
 def get_worker_supply(observation):
     return observation.player_common.food_workers
+
+def get_idle_worker_count(observation):
+    return observation.player_common.idle_worker_count


### PR DESCRIPTION
I have extended the Pathlib implementation so that, if there is a valid local config.json file in the CWD where reaper is being run, reaper uses that file, otherwise, it defaults to the config.json in the sc2reaper folder. 

The validation is done using jsonschema.validate, to check that all the necessary fields exist.

Regarding the features collected in the Mongodb, I also added the idle_workers to the states' collection (edit in state_extraction.py) and I added the "idle_production_time" to the scores collection (edit in the score_extraction.py). These features can be useful for profiling types of players.  
